### PR TITLE
Update vercel deploy to new github url

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ A modern, web-based application for managing your Hayward Omni pool automation s
 
 1. **Clone the repository**
    ```bash
-   git clone <repository-url>
-   cd hayward-omni-pool-manager
+   git clone https://github.com/TimFerrell/nightswim
+   cd nightswim
    ```
 
 2. **Install dependencies**
@@ -55,7 +55,7 @@ A modern, web-based application for managing your Hayward Omni pool automation s
 ### Deploy to Vercel
 
 #### One-Click Deploy
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/your-repo/hayward-omni-pool-manager)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/TimFerrell/nightswim)
 
 #### Manual Deploy
 


### PR DESCRIPTION
Update Vercel one-click deploy button and git clone instructions to use the correct repository URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-d6b82875-f54c-4c0b-ad4f-e0d90ed0f70e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d6b82875-f54c-4c0b-ad4f-e0d90ed0f70e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>